### PR TITLE
Global CONFIG_FILE variable defined without extern in header file

### DIFF
--- a/src/umonitor.c
+++ b/src/umonitor.c
@@ -93,6 +93,8 @@ static const struct option long_options[] = {
 	{"force-load", no_argument, &force_load, 1}
 };
 
+/* Definition checked against declaration in umonitor.h */
+char* CONFIG_FILE;
 
 void umon_print(const char *format, ...)
 {

--- a/src/umonitor.h
+++ b/src/umonitor.h
@@ -1,5 +1,5 @@
 // Global variables
-char *CONFIG_FILE;		/*!< Configuration file path name */
+extern char *CONFIG_FILE;		/*!< Configuration file path name */
 
 // Some helper functions
 void fetch_edid(xcb_randr_output_t * output_p, screen_class * screen_t_p,


### PR DESCRIPTION
  Since GCC 10.1.0 (2020-05-07) default compilation options to use -fno-common, which means that by default, the code above no longer links unless you override the default with -fcommon